### PR TITLE
[fix] Workshop: don't prefill all available rounds

### DIFF
--- a/js/workshop.js
+++ b/js/workshop.js
@@ -55,7 +55,8 @@ class Workshop
 			const roundsLeftArr = $(tr).find('td:nth(2)').text().replace(/[\sa-z]/g, '').split('/');
 			const roundsLeft = parseInt(roundsLeftArr[1]) - parseInt(roundsLeftArr[0]);
 
-			let workRounds = playerRounds;
+			// Rationale: don't use up all available rounds
+			let workRounds = playerRounds - 1;
 			if (roundsLeft < workRounds) {
 				workRounds = roundsLeft;
 			}


### PR DESCRIPTION
Don't prefill rounds input with _all_ available rounds. Instead leave one round for players to be able to participate in team games etc.