### PR TITLE
[fix] Highlight name in duel report header and footer

### DIFF
--- a/js/edrania.js
+++ b/js/edrania.js
@@ -127,9 +127,12 @@ chrome.storage.sync.get('edraniaConfig', function(data){
 			css['color'] = edraniaConfig.duelHighlightColor;
 		}
 
-		$('.duelName').filter(function(){
-			return ($(this).text() === name);
-		}).css(css);
+		$("#centerContent")
+			.find(".duelName, .fat, b")
+			.filter(function () {
+				return $(this).text() === name;
+			})
+			.css(css);
 	}
 	else if (path === '/Workshop/') {
 		new Workshop('list');


### PR DESCRIPTION
I found it annoying that the gladiator name wasn't highlighted with the custom color in the header and footer of the duel report.

**Before**

_Header_
![image](https://user-images.githubusercontent.com/516549/112228633-e482de00-8c31-11eb-8d11-d09263ff06a2.png)

_Footer_
![image](https://user-images.githubusercontent.com/516549/112228644-e77dce80-8c31-11eb-89e1-2b7e39ff9d9c.png)

**After**

_Header_
![image](https://user-images.githubusercontent.com/516549/112228654-eba9ec00-8c31-11eb-844f-decc6bb7aae1.png)
_Footer_
![image](https://user-images.githubusercontent.com/516549/112228661-ee0c4600-8c31-11eb-9ada-d52bb892bc65.png)
