### PR TITLE
[feat]: Vendor: purchase equipment without confirm

### DIFF
--- a/js/edrania.js
+++ b/js/edrania.js
@@ -85,6 +85,9 @@ chrome.storage.sync.get('edraniaConfig', function(data){
 	if (path === '/Auction/') {
 		new Auction();
 	}
+	else if (path.startsWith('/Vendor/Browse/') && edraniaConfig.purchaseEquipmentWithoutConfirm) {
+		new Vendor();
+	}
 	else if (path === '/TeamGame/') {
 		new TeamGame('list');
 	}

--- a/js/vendor.js
+++ b/js/vendor.js
@@ -1,0 +1,23 @@
+class Vendor
+{
+	constructor()
+	{
+		this.initPurchaseEquipmentWithoutConfirm();
+	}
+
+	initPurchaseEquipmentWithoutConfirm()
+	{
+		$('.table-body-border tr').each((_, tableRow) => {
+			const $purchaseButton = $(tableRow).find('a[href^="/Vendor/Purchase/"]');
+			const itemID = $purchaseButton.attr('href').split('/').pop();
+
+			$purchaseButton.on('click', (event) => {
+				event.preventDefault();
+
+				$.post('/Vendor/PurchaseItem/', { ItemID: itemID }, () => {
+					location.reload();
+				});
+			});
+		})
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
 				"/js/prefill.js",
 				"/js/hoverInfo.js",
 				"/js/auction.js",
+				"/js/vendor.js",
 				"/js/teamGame.js",
 				"/js/challenges.js",
 				"/js/tavern.js",

--- a/popup.html
+++ b/popup.html
@@ -29,6 +29,11 @@
 		</tr>
 		<tr>
 			<td>
+				<label><input class="js-set-config" type="checkbox" name="purchaseEquipmentWithoutConfirm"> Köp utrustning utan bekräftelse</label>
+			</td>
+		</tr>
+		<tr>
+			<td>
 				<label><input class="js-set-config" type="checkbox" name="highlightInDuels"> Highlighta dig själv i dueller</label>
 			</td>
 		</tr>


### PR DESCRIPTION
Adds ability to purchase equipment directly from the list view, without navigating to the confirmation page.

Since it could be considered a somewhat destructive action, I chose to require users to opt-in via settings.