### PR TITLE
[fix] Workshop: min default rounds to 0

### DIFF
--- a/js/workshop.js
+++ b/js/workshop.js
@@ -56,7 +56,7 @@ class Workshop
 			const roundsLeft = parseInteger(roundsLeftArr[1]) - parseInteger(roundsLeftArr[0]);
 
 			// Rationale: don't use up all available rounds
-			const workRounds = Math.min(playerRounds - 1, roundsLeft);
+			const workRounds = Math.max(Math.min(playerRounds - 1, roundsLeft), 0);
 			const maxRounds = Math.min(playerRounds, roundsLeft);
 
 			const $td = $('<td>');


### PR DESCRIPTION
When player has 0 rounds or less left, the work input will be set to negative rounds. Set 0 as minimum.