### PR TITLE
[fix] Hover info – team game: show 0 for empty team

### DIFF
--- a/js/hoverInfo.js
+++ b/js/hoverInfo.js
@@ -283,7 +283,7 @@ class HoverInfo
 			hardestHit = this.getHardestHit(results[0]);
 		}
 
-		if (hardestHit === undefined) {
+		if (typeof hardestHit === "undefined" || Number.isNaN(hardestHit)) {
 			hardestHit = 0;
 		}
 


### PR DESCRIPTION
Currently shows `NaN`.