### PR TITLE
[fix] Team game list: dedupe adjacent dividers

### DIFF
--- a/js/teamGame.js
+++ b/js/teamGame.js
@@ -65,6 +65,9 @@ class TeamGame
 								$tr.show();
 							}
 						});
+
+						// Remove superfluous divider, mainly to avoid showing adjacent dividers.
+						$('.compact-table:first tbody tr:empty:first').hide();
 					}
 					else {
 						$('.compact-table:first tbody tr').show();


### PR DESCRIPTION
Removes seemingly superfluous first divider when filtering.

**Before**
![image](https://user-images.githubusercontent.com/516549/113183361-39d37680-9254-11eb-8cfb-2df376031861.png)

**After**
![image](https://user-images.githubusercontent.com/516549/113183302-245e4c80-9254-11eb-9ff4-87387bebe9c8.png)
