### PR TITLE
[feat] Search gladiator: persistent filter across page navigation

### DIFF
--- a/js/auction.js
+++ b/js/auction.js
@@ -2,12 +2,54 @@ class Auction
 {
 	constructor()
 	{
-		this.initSearchPage();
+		this.initTableChangeObserver();
+		this.initPersistentFilter();
 	}
 
-	initSearchPage()
+	applyFreeSearchFilter()
+	{
+		const $search = $('#freeSearch');
+		const query = $search.val();
+
+		if (typeof query === "undefined" || query.length === 0) {
+			return;
+		}
+
+		// Why a native event?
+		// Our version of jQuery is not run in the same sandbox as the page's jQuery.
+		// Hence, the synthetic jQuery events cache is not shared.
+		const keyUpEvent = new KeyboardEvent('keyup');
+		$search[0].dispatchEvent(keyUpEvent);
+	}
+
+	initTableChangeObserver()
 	{
 		// Create observer for changes on incoming table
-		new EdraniaObserver($('#auctionTblBody')[0], () => {hoverInfo.initHover()});
+		new EdraniaObserver($('#auctionTblBody')[0], () => {
+			hoverInfo.initHover();
+			this.applyFreeSearchFilter();
+		});
+	}
+
+	initPersistentFilter()
+	{
+		const fieldByName = {
+			search: $('#freeSearch'),
+			'min-level': $('#minLevel'),
+			'max-level': $('#maxLevel'),
+			category: $('#itemCategory'),
+			type: $('#itemType'),
+			race: $('#raceRequirement'),
+		};
+		const defaultValueByName = {
+			search: "",
+			"min-level": "1",
+			"max-level": "99",
+			category: "-1",
+			type: "-1",
+			race: "-1",
+		};
+
+		new PersistentFilter(fieldByName, defaultValueByName);
 	}
 }

--- a/js/edrania.js
+++ b/js/edrania.js
@@ -149,6 +149,9 @@ chrome.storage.sync.get('edraniaConfig', function(data){
 	else if (path === '/Workshop/NewProject/') {
 		new Workshop('new');
 	}
+	else if (path.startsWith('/Search/Gladiator/')) {
+		new SearchGladiator();
+	}
 	else if (path === '/MyGlad/LevelUp/') {
 		talentCalculator.placeLevelUp();
 	}

--- a/js/persistentFilter.js
+++ b/js/persistentFilter.js
@@ -1,0 +1,129 @@
+class PersistentFilter {
+	constructor(fieldByName, defaultValueByName)
+	{
+		this.fieldByName = fieldByName;
+		this.defaultValueByName = defaultValueByName;
+
+		this.filter = {};
+		this.$reset = this.createFilterReset();
+
+		this.initPersistentFilter();
+		this.initFilterReset();
+	}
+
+	persistFilterInURL()
+	{
+		const url = new URL(window.location.href);
+		const queryParameters = new URLSearchParams(url.search);
+		Object.entries(this.filter).forEach(([key, value]) => {
+			if (value !== this.defaultValueByName[key]) {
+				queryParameters.set(key, value);
+			}
+			else {
+				queryParameters.delete(key);
+			}
+		});
+		url.search = queryParameters;
+		history.replaceState(null, '', url.toString());
+	}
+
+	readFilterFromURL()
+	{
+		const url = new URL(window.location.href);
+		const queryParameters = new URLSearchParams(url.search);
+		[...queryParameters.entries()]
+			.filter(([key, value]) => value !== this.defaultValueByName[key])
+			.forEach(([key, value]) => {
+				this.filter[key] = value;
+			});
+	}
+
+	resetFilter()
+	{
+		this.setFieldValues(this.defaultValueByName);
+		this.applyFilter();
+	}
+
+	createFilterReset()
+	{
+		return $('<input/>', {
+			type: 'reset',
+			value: 'Återställ',
+			css: {
+				display: 'none',
+				marginLeft: '4px'
+			},
+			click: (event) => {
+				event.preventDefault();
+
+				this.resetFilter();
+			}
+		});
+	}
+
+	setFieldValues(valueByName)
+	{
+		Object.entries(valueByName).forEach(([key, value]) => {
+			this.fieldByName[key].val(value).trigger('change');
+		});
+	}
+
+	initFilterReset()
+	{
+		$('#centerContent input[type="submit"]:last').after(this.$reset);
+		this.updateResetVisibility();
+	}
+
+	applyFilter()
+	{
+		$('#centerContent input[type="submit"]:first').click();
+	}
+
+	updateResetVisibility()
+	{
+		const isDirty = Object.entries(this.fieldByName).some(
+			([name, $field]) => {
+				const value = $field.val();
+
+				return typeof value !== "undefined" &&
+					value !== this.defaultValueByName[name];
+			}
+		);
+
+		this.$reset.toggle(isDirty);
+	}
+
+	initPersistentFilter() {
+		// Sync filter and URL
+		if (window.window.location.search.length > 0) {
+			this.readFilterFromURL();
+			this.setFieldValues(this.filter);
+			this.applyFilter();
+		}
+		else {
+			Object.entries(this.fieldByName)
+				.filter(([name, $field]) => {
+					const value = $field.val();
+
+					return (
+						typeof value !== 'undefined' &&
+						value.trim() !== this.defaultValueByName[name]
+					);
+				})
+				.forEach(([name, $field]) => {
+					this.filter[name] = $field.val().trim();
+				});
+
+			this.persistFilterInURL();
+		}
+
+		// Sync filter changes to URL
+		Object.entries(this.fieldByName).forEach(([name, $field]) => {
+			$field.on('change', () => {
+				this.filter[name] = $field.val().trim();
+				this.persistFilterInURL();
+				this.updateResetVisibility();
+			});
+		});
+	}
+}

--- a/js/searchGladiator.js
+++ b/js/searchGladiator.js
@@ -1,18 +1,12 @@
-const DefaultValue = Object.freeze({
-	name: "",
-	username: "",
-	clan: "",
-	race: "5",
-	"min-level": "1",
-	"max-level": "99",
-	age: "4"
-});
-
 class SearchGladiator {
 	constructor() 
 	{
-		this.filter = {};
-		this.fieldByName = {
+		this.initPersistentFilter();
+	}
+
+	initPersistentFilter()
+	{
+		const fieldByName = {
 			name: $('#GladiatorName'),
 			username: $('#Username'),
 			clan: $('#ClanName'),
@@ -21,120 +15,16 @@ class SearchGladiator {
 			'max-level': $('#MaximumLevel'),
 			age: $('#Age'),
 		};
-		this.$reset = this.createFilterReset();
+		const defaultValueByName = {
+			name: "",
+			username: "",
+			clan: "",
+			race: "5",
+			"min-level": "1",
+			"max-level": "99",
+			age: "4"
+		};
 
-		this.initPersistentFilter();
-		this.initFilterReset();
-	}
-
-	persistFilterInURL() 
-	{
-		const url = new URL(window.location.href);
-		const queryParameters = new URLSearchParams(url.search);
-		Object.entries(this.filter).forEach(([key, value]) => {
-			if (value !== DefaultValue[key]) {
-				queryParameters.set(key, value);
-			}
-			else {
-				queryParameters.delete(key);
-			}
-		});
-		url.search = queryParameters;
-		history.replaceState(null, '', url.toString());
-	}
-
-	readFilterFromURL() 
-	{
-		const url = new URL(window.location.href);
-		const queryParameters = new URLSearchParams(url.search);
-		[...queryParameters.entries()]
-			.filter(([key, value]) => value !== DefaultValue[key])
-			.forEach(([key, value]) => {
-				this.filter[key] = value;
-			});
-	}
-
-	resetFilter()
-	{
-		this.setFieldValues(DefaultValue);
-	}
-
-	createFilterReset()
-	{
-		return $('<input/>', {
-			type: 'reset',
-			value: 'Återställ',
-			css: {
-				display: 'none',
-				marginLeft: '4px'
-			},
-			click: (event) => {
-				event.preventDefault();
-
-				this.resetFilter();
-			}
-		});
-	}
-
-	setFieldValues(valueByName)
-	{
-		Object.entries(valueByName).forEach(([key, value]) => {
-			this.fieldByName[key].val(value).trigger('change');
-		});
-	}
-
-	initFilterReset()
-	{
-		$('#btnChallenge').after(this.$reset);
-		this.updateResetVisibility();
-	}
-
-	updateResetVisibility()
-	{
-		const isDirty = Object.entries(this.fieldByName).some(
-			([name, $field]) => {
-				const value = $field.val();
-
-				return typeof value !== "undefined" &&
-					value !== DefaultValue[name];
-			}
-		);
-
-		this.$reset.toggle(isDirty);
-	}
-
-	initPersistentFilter() {
-		// Sync filter and URL
-		if (window.window.location.search.length > 0) {
-			this.readFilterFromURL();
-			this.setFieldValues(this.filter);
-
-			$('#centerContent form').submit();
-		}
-		else {
-			Object.entries(this.fieldByName)
-				.filter(([name, $field]) => {
-					const value = $field.val();
-					
-					return (
-						typeof value !== 'undefined' &&
-						value.trim() !== DefaultValue[name]
-					);
-				})
-				.forEach(([name, $field]) => {
-					this.filter[name] = $field.val().trim();
-				});
-
-			this.persistFilterInURL();
-		}
-		
-		// Sync filter changes to URL
-		Object.entries(this.fieldByName).forEach(([name, $field]) => {
-			$field.on('change', () => {
-				this.filter[name] = $field.val().trim();
-				this.persistFilterInURL();
-				this.updateResetVisibility();
-			});
-		});
+		new PersistentFilter(fieldByName, defaultValueByName);
 	}
 }

--- a/js/searchGladiator.js
+++ b/js/searchGladiator.js
@@ -1,0 +1,140 @@
+const DefaultValue = Object.freeze({
+	name: "",
+	username: "",
+	clan: "",
+	race: "5",
+	"min-level": "1",
+	"max-level": "99",
+	age: "4"
+});
+
+class SearchGladiator {
+	constructor() 
+	{
+		this.filter = {};
+		this.fieldByName = {
+			name: $('#GladiatorName'),
+			username: $('#Username'),
+			clan: $('#ClanName'),
+			race: $('#Race'),
+			'min-level': $('#MinimumLevel'),
+			'max-level': $('#MaximumLevel'),
+			age: $('#Age'),
+		};
+		this.$reset = this.createFilterReset();
+
+		this.initPersistentFilter();
+		this.initFilterReset();
+	}
+
+	persistFilterInURL() 
+	{
+		const url = new URL(window.location.href);
+		const queryParameters = new URLSearchParams(url.search);
+		Object.entries(this.filter).forEach(([key, value]) => {
+			if (value !== DefaultValue[key]) {
+				queryParameters.set(key, value);
+			}
+			else {
+				queryParameters.delete(key);
+			}
+		});
+		url.search = queryParameters;
+		history.replaceState(null, '', url.toString());
+	}
+
+	readFilterFromURL() 
+	{
+		const url = new URL(window.location.href);
+		const queryParameters = new URLSearchParams(url.search);
+		[...queryParameters.entries()]
+			.filter(([key, value]) => value !== DefaultValue[key])
+			.forEach(([key, value]) => {
+				this.filter[key] = value;
+			});
+	}
+
+	resetFilter()
+	{
+		this.setFieldValues(DefaultValue);
+	}
+
+	createFilterReset()
+	{
+		return $('<input/>', {
+			type: 'reset',
+			value: 'Återställ',
+			css: {
+				display: 'none',
+				marginLeft: '4px'
+			},
+			click: (event) => {
+				event.preventDefault();
+
+				this.resetFilter();
+			}
+		});
+	}
+
+	setFieldValues(valueByName)
+	{
+		Object.entries(valueByName).forEach(([key, value]) => {
+			this.fieldByName[key].val(value).trigger('change');
+		});
+	}
+
+	initFilterReset()
+	{
+		$('#btnChallenge').after(this.$reset);
+		this.updateResetVisibility();
+	}
+
+	updateResetVisibility()
+	{
+		const isDirty = Object.entries(this.fieldByName).some(
+			([name, $field]) => {
+				const value = $field.val();
+
+				return typeof value !== "undefined" &&
+					value !== DefaultValue[name];
+			}
+		);
+
+		this.$reset.toggle(isDirty);
+	}
+
+	initPersistentFilter() {
+		// Sync filter and URL
+		if (window.window.location.search.length > 0) {
+			this.readFilterFromURL();
+			this.setFieldValues(this.filter);
+
+			$('#centerContent form').submit();
+		}
+		else {
+			Object.entries(this.fieldByName)
+				.filter(([name, $field]) => {
+					const value = $field.val();
+					
+					return (
+						typeof value !== 'undefined' &&
+						value.trim() !== DefaultValue[name]
+					);
+				})
+				.forEach(([name, $field]) => {
+					this.filter[name] = $field.val().trim();
+				});
+
+			this.persistFilterInURL();
+		}
+		
+		// Sync filter changes to URL
+		Object.entries(this.fieldByName).forEach(([name, $field]) => {
+			$field.on('change', () => {
+				this.filter[name] = $field.val().trim();
+				this.persistFilterInURL();
+				this.updateResetVisibility();
+			});
+		});
+	}
+}

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
 				"/js/vendor/jquery-3.5.1.min.js",
 				"/js/prefill.js",
 				"/js/hoverInfo.js",
+				"/js/persistentFilter.js",
 				"/js/auction.js",
 				"/js/vendor.js",
 				"/js/teamGame.js",

--- a/manifest.json
+++ b/manifest.json
@@ -33,6 +33,7 @@
 				"/js/observer.js",
 				"/js/workDistrict.js",
 				"/js/workshop.js",
+				"/js/searchGladiator.js",
 				"/js/edrania.js"
 			],
 			"css": [


### PR DESCRIPTION
- Search gladiator
- Auctions
  - Bonus: Apply free search filter (again) after applying other filters
- Reset filter button

**Demo**

https://user-images.githubusercontent.com/516549/113363430-1fcb8e00-9351-11eb-8460-c39e9de22884.mov

**Note:** contrary to what the demo shows, there's no longer any need to press **Search/Filter** after resetting the filter.

