### PR TITLE
[fix] Team game: POST toggle ready state

### DIFF
--- a/js/teamGame.js
+++ b/js/teamGame.js
@@ -109,14 +109,9 @@ class TeamGame
 		return location.pathname.split('/').pop();
 	}
 
-	getToggleReadyStateURL()
-	{
-		return `/TeamGame/${this.getGameID()}/ToggleReadyState`;
-	}
-
 	getPlayerReadyStateElement()
 	{
-		return $(`a[href="${this.getToggleReadyStateURL()}"]`);
+		return $(`a[href="/TeamGame/${this.getGameID()}/ToggleReadyState"]`);
 	}
 
 	/**
@@ -226,8 +221,9 @@ class TeamGame
 		}
 
 		if (!this.isPlayerReady()) {
-			this.setPlayerReadyRequest = $.get(
-				this.getToggleReadyStateURL(),
+			this.setPlayerReadyRequest = $.post(
+				'/TeamGame/ToggleReadyState',
+				{ data: this.getGameID() },
 				() => {
 					if (!this.isPlayerReady()) {
 						this.getPlayerReadyStateElement().text("Redo");


### PR DESCRIPTION
Should fix the auto-ready issues, once and for all.

I observed how the feature behaved from a spectator view and got consistently lacking results. Hence, I started looking into what differed from the manual process of clicking the link. Monitoring the network requests revealed that _two_ requests were being sent, one GET request (the link href) and one additional POST request (a click handler must be attached to the link). The second request is key and is what the plugin missed.

Not sure what function the GET request actually fills, but no worries. I've beta-tested this with another player and it now seemingly work flawlessly.