### PR TITLE
[fix] Adjust estimated damage bonus formula

### DIFF
--- a/js/attributes.js
+++ b/js/attributes.js
@@ -7,10 +7,13 @@ class Attributes
 
 	initDisplayDerivedDamageBonusFromStrength()
 	{
-		const $strength = $('#centerContent th:contains("Styrka")').next();
+		const $strength = $('#centerContent')
+			.find('th:contains("Styrka"), #centerContent th:contains("Strength")')
+			.next();
 		const strength = parseInteger($strength.text());
-		const damageBonus = Math.floor(strength / 10);
+		const normalDamageBonus = Math.floor(strength * 0.09);
+		const title = `${Math.floor(strength * 0.07)}-${Math.floor(strength * 0.11)} skadebonus (lätta-tunga attacker)`;
 		
-		$strength.append(` (~${damageBonus} skadebonus)`)
+		$strength.append(` (~${normalDamageBonus} skadebonus)`).attr('title', title);
 	}
 }

--- a/js/duelReport.js
+++ b/js/duelReport.js
@@ -32,9 +32,9 @@ class DuelReport
 	is1on1()
 	{
 		return (
-			$('b:contains("Lag"):first')
+			$('b:contains("Lag"):first, b:contains("Team"):first')
 				.siblings()
-				.filter('a,b:not(:contains("Lag"))').length === 2
+				.filter('a,b:not(:contains("Lag")),b:not(:contains("Team"))').length === 2
 		);
 	}
 

--- a/js/edrania.js
+++ b/js/edrania.js
@@ -202,6 +202,6 @@ chrome.storage.sync.get('edraniaConfig', function(data){
 		$endurance.attr('title', `~${Math.floor(parseFloat($endurance.text()) / 4 + 3)} rundor`);
 
 		const $strength = $('#calcStrength');
-		$strength.attr('title', `~${Math.floor(parseFloat($strength.text()) / 10)} skadebonus`);
+		$strength.attr('title', `~${Math.floor(parseFloat($strength.text()) * 0.09)} skadebonus`);
 	}
 });


### PR DESCRIPTION
`strength * 0.09` has proven to be more accurate than `strength / 10` for normal attacks.

- Add tooltip with range
- Handle English text in selectors